### PR TITLE
Use built-in formatter with CLEF format

### DIFF
--- a/logruseq.go
+++ b/logruseq.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -21,6 +22,7 @@ func NewSeqHook(host string) *SeqHook {
 
 func (hook *SeqHook) Fire(entry *logrus.Entry) error {
 	formatter := logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
 		FieldMap: logrus.FieldMap{
 			logrus.FieldKeyMsg:   "@mt",
 			logrus.FieldKeyLevel: "@l",


### PR DESCRIPTION
Along with the original `"Events":[...` JSON format, Seq accepts a nicer "compact" JSON format detailed in: https://github.com/serilog/serilog-formatting-compact#format-details

This change switches over to that format, and as a side-effect can now make use of the built-in logrus `JSONFormatter` type.