### PR TITLE
Support optional API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ func main() {
     }).Info("A walrus appears")
 }
 ```
+
+API keys can be specified optionally with:
+
+```go
+    logrus.AddHook(logruseq.NewSeqHook("http://localhost:5341",
+                logruseq.OptionAPIKey("N1ncujiT5pYGD6m4CF0")))
+```


### PR DESCRIPTION
Adds the ability to specify an API key, for "production-y" Seq use.

```go
// Still supported - no API key
logrus.AddHook(logruseq.NewSeqHook("http://localhost:5341"))

// Hook with API key
logrus.AddHook(logruseq.NewSeqHook("http://localhost:5341",
               logruseq.OptionAPIKey("N1ncujiT5pYGD6m4CF0")))
```

I took the variadic "options" path because passing an `Options` struct meant coming up with another function name, or always requiring `nil` in the simple case. Happy to head in the other direction if you'd prefer :-)

Works-on-my-machine screenshot:

![image](https://user-images.githubusercontent.com/342712/33112252-02c77c76-cf9e-11e7-8a16-b482a6621358.png)

Further options the hook might support someday are:

 * Async/batching behavior and associated limits
 * Payload size and event size limits
